### PR TITLE
feat: /apply auto-apply flow

### DIFF
--- a/backend/app/chains/__init__.py
+++ b/backend/app/chains/__init__.py
@@ -15,7 +15,6 @@ from backend.app.chains.skill_chain import build_skill_chain
 from backend.app.chains.job_match_chain import build_job_match_chain
 from backend.app.chains.cover_letter_chain import build_cover_letter_chain
 from backend.app.chains.resume_writer_chain import build_resume_writer_chain
-from backend.app.chains.apply_agent import build_apply_agent
 
 __all__ = [
     "build_resume_chain",
@@ -23,5 +22,4 @@ __all__ = [
     "build_job_match_chain",
     "build_cover_letter_chain",
     "build_resume_writer_chain",
-    "build_apply_agent",
 ]

--- a/backend/app/services/resume_processor.py
+++ b/backend/app/services/resume_processor.py
@@ -91,7 +91,7 @@ def extract_contact_info(text: str) -> dict:
     emails = re.findall(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b", text)
     if emails:
         info["email"] = emails[0]
-    phones = re.findall(r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b", text)
+    phones = re.findall(r"\b(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})\b", text)
     if phones:
         info["phone"] = f"({phones[0][0]}) {phones[0][1]}-{phones[0][2]}"
     return info

--- a/frontend/app/apply/page.tsx
+++ b/frontend/app/apply/page.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { supabase } from '@/lib/supabase';
+import { getApiBaseUrl } from '@/lib/api';
+
+type TaskStatusPayload = {
+  task_id: string;
+  status: string;
+  result?: unknown;
+};
+
+function parseUrls(raw: string): string[] {
+  return raw
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export default function ApplyPage() {
+  const router = useRouter();
+  const [userId, setUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [jobUrlText, setJobUrlText] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState('');
+  const [info, setInfo] = useState('');
+  const [taskIds, setTaskIds] = useState<string[]>([]);
+  const [statusByTask, setStatusByTask] = useState<Record<string, TaskStatusPayload>>({});
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const fetchStatus = useCallback(async (ids: string[]) => {
+    const next: Record<string, TaskStatusPayload> = {};
+    for (const id of ids) {
+      try {
+        const res = await fetch(`${getApiBaseUrl()}/apply/status/${id}`);
+        const data = (await res.json()) as TaskStatusPayload;
+        if (res.ok) {
+          next[id] = data;
+        } else {
+          next[id] = { task_id: id, status: 'ERROR', result: data };
+        }
+      } catch (e) {
+        next[id] = {
+          task_id: id,
+          status: 'ERROR',
+          result: e instanceof Error ? e.message : 'fetch failed',
+        };
+      }
+    }
+    setStatusByTask((prev) => ({ ...prev, ...next }));
+
+    const allTerminal = ids.every((id) => {
+      const s = next[id]?.status;
+      return s === 'SUCCESS' || s === 'FAILURE' || s === 'REVOKED' || s === 'ERROR';
+    });
+    if (allTerminal) {
+      stopPolling();
+    }
+  }, [stopPolling]);
+
+  useEffect(() => {
+    const run = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        router.push('/login');
+        return;
+      }
+      setUserId(session.user.id);
+      setEmail((e) => e || session.user.email || '');
+      setLoading(false);
+    };
+    run();
+  }, [router]);
+
+  useEffect(() => {
+    return () => stopPolling();
+  }, [stopPolling]);
+
+  const handleStart = async () => {
+    setError('');
+    setInfo('');
+    const urls = parseUrls(jobUrlText);
+    if (!userId || urls.length === 0) {
+      setError('Sign in and enter at least one job URL.');
+      return;
+    }
+
+    setStarting(true);
+    stopPolling();
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/apply/start`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: userId,
+          job_urls: urls,
+          credentials: { email: email.trim(), password },
+          preferences: {},
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        const d = (data as { detail?: unknown })?.detail;
+        setError(typeof d === 'string' ? d : `Start failed (${res.status})`);
+        setStarting(false);
+        return;
+      }
+
+      const taskIdRaw = (data as { task_id?: string }).task_id || '';
+      const ids = taskIdRaw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      setTaskIds(ids);
+      setInfo(`Queued ${(data as { jobs_queued?: number }).jobs_queued ?? ids.length} application task(s). Polling status…`);
+
+      await fetchStatus(ids);
+
+      pollRef.current = setInterval(() => {
+        void fetchStatus(ids);
+      }, 2500);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Network error — is the API and Celery worker running?');
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <main className="min-h-screen bg-black text-white flex items-center justify-center">
+        Loading…
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-black text-white pt-24 px-6 pb-16">
+      <div className="max-w-2xl mx-auto space-y-8">
+        <div>
+          <h1 className="text-3xl font-bold mb-2">Auto-apply</h1>
+          <p className="text-white/60 text-sm">
+            POST to <code className="text-white/80">{getApiBaseUrl()}/apply/start</code> and poll{' '}
+            <code className="text-white/80">/apply/status/{"{task_id}"}</code>. Requires a running API and Celery worker
+            with Redis.
+          </p>
+        </div>
+
+        {error && <div className="p-3 rounded-lg border border-red-400/30 bg-red-500/10 text-red-200 text-sm">{error}</div>}
+        {info && <div className="p-3 rounded-lg border border-sky-400/30 bg-sky-500/10 text-sky-100 text-sm">{info}</div>}
+
+        <div className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-2xl p-6 space-y-5">
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-white/80">Job URLs (one per line)</label>
+            <textarea
+              value={jobUrlText}
+              onChange={(e) => setJobUrlText(e.target.value)}
+              rows={5}
+              placeholder="https://boards.greenhouse.io/..."
+              className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/35 focus:outline-none focus:border-white/30"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-white/80">Portal email (optional)</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-xl text-white"
+                autoComplete="email"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-white/80">Portal password (optional)</label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-xl text-white"
+                autoComplete="current-password"
+              />
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => void handleStart()}
+            disabled={starting}
+            className="px-5 py-2.5 rounded-xl bg-white text-black font-semibold hover:bg-white/90 disabled:opacity-50"
+          >
+            {starting ? 'Starting…' : 'Queue applications'}
+          </button>
+        </div>
+
+        {taskIds.length > 0 && (
+          <div className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-2xl p-6">
+            <h2 className="text-lg font-semibold mb-4">Task status</h2>
+            <ul className="space-y-3 text-sm">
+              {taskIds.map((id) => {
+                const st = statusByTask[id];
+                return (
+                  <li key={id} className="border border-white/10 rounded-lg p-3 bg-black/20">
+                    <div className="text-white/50 text-xs break-all mb-1">{id}</div>
+                    <div className="text-white/90">
+                      Status: <span className="text-amber-200">{st?.status ?? '…'}</span>
+                    </div>
+                    {st?.result != null && (
+                      <pre className="text-xs text-white/50 mt-2 overflow-x-auto max-h-32">
+                        {JSON.stringify(st.result, null, 2)}
+                      </pre>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+
+        <p className="text-white/45 text-sm">
+          Track outcomes on the{' '}
+          <Link href="/dashboard" className="text-sky-300 underline">
+            dashboard
+          </Link>{' '}
+          once rows are written to your backend database.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 
 /**
  * Finishes Google OAuth. The Supabase client reads tokens from the redirect URL
@@ -13,7 +14,7 @@ export default function AuthCallbackPage() {
   const [message, setMessage] = useState('Signing in…');
 
   useEffect(() => {
-    const { data: listener } = supabase.auth.onAuthStateChange((event, session) => {
+    const { data: listener } = supabase.auth.onAuthStateChange((event: AuthChangeEvent, session: Session | null) => {
       if (session && (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED')) {
         listener.subscription.unsubscribe();
         router.replace('/dashboard');

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 
 type DashboardJob = {
   id: string;
@@ -191,7 +192,7 @@ export default function Dashboard() {
     // Listen for auth changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange((_event: AuthChangeEvent, session: Session | null) => {
       if (!session) {
         router.push('/login');
       } else {

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import LiquidGlassButton from './LiquidGlassButton';
 import { supabase } from '@/lib/supabase';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 
 export default function Navbar() {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -22,7 +23,8 @@ export default function Navbar() {
 
   useEffect(() => {
     // Check initial auth state
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    supabase.auth.getSession().then(({ data }: { data: { session: Session | null } }) => {
+      const { session } = data;
       setIsSignedIn(!!session);
       setUserEmail(session?.user?.email || '');
     });
@@ -30,7 +32,7 @@ export default function Navbar() {
     // Listen for auth changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange((_event: AuthChangeEvent, session: Session | null) => {
       setIsSignedIn(!!session);
       setUserEmail(session?.user?.email || '');
     });
@@ -79,13 +81,30 @@ export default function Navbar() {
           {/* Right Actions */}
           <div className="flex items-center space-x-4">
             {isSignedIn ? (
-              // Signed In: Show Dashboard and Sign Out
+              // Signed In: Show app nav and Sign Out
               <>
+                <Link
+                  href="/dashboard"
+                  className="hidden sm:block text-sm font-medium text-white/70 hover:text-white transition-colors"
+                >
+                  Dashboard
+                </Link>
+                <Link
+                  href="/apply"
+                  className="hidden sm:block text-sm font-medium text-white/70 hover:text-white transition-colors"
+                >
+                  Auto-apply
+                </Link>
+                <Link
+                  href="/profile"
+                  className="hidden sm:block text-sm font-medium text-white/70 hover:text-white transition-colors"
+                >
+                  Profile
+                </Link>
                 <Link
                   href="/dashboard"
                   className="flex items-center space-x-2 text-sm font-medium text-white hover:opacity-80 transition-opacity"
                 >
-                  <span className="hidden md:inline">Dashboard</span>
                   <span className="px-2 py-1 text-xs font-medium bg-white/10 text-white rounded border border-white/20">
                     {userEmail.charAt(0).toUpperCase()}
                   </span>

--- a/frontend/components/UploadForm.tsx
+++ b/frontend/components/UploadForm.tsx
@@ -1,24 +1,235 @@
-import { useState } from 'react';
+'use client';
 
-export default function UploadForm() {
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { getApiBaseUrl } from '@/lib/api';
+
+export type ParseResumeResponse = {
+  file_name?: string;
+  profile?: Record<string, unknown>;
+  skills?: { skills?: string[]; categorized?: Record<string, unknown> };
+  contact_info?: { email?: string; phone?: string } | null;
+  processing_status?: string;
+  error?: string;
+};
+
+type ParseState = 'idle' | 'uploading' | 'saving' | 'success' | 'error';
+
+function buildExperiencePayload(
+  data: ParseResumeResponse
+): { text: string; parsed: unknown; contact_info: unknown; parsed_at: string } {
+  const profile = (data.profile || {}) as {
+    summary?: string;
+    experience?: Array<{ company?: string; title?: string; description?: string }>;
+    education?: Array<{ degree?: string; institution?: string }>;
+  };
+  const lines: string[] = [];
+  if (profile.summary) lines.push(profile.summary);
+  if (Array.isArray(profile.experience)) {
+    for (const ex of profile.experience) {
+      const t = [ex.title, ex.company].filter(Boolean).join(' @ ');
+      if (t) lines.push(t);
+      if (ex.description) lines.push(ex.description);
+    }
+  }
+  if (Array.isArray(profile.education)) {
+    for (const ed of profile.education) {
+      const t = [ed.degree, ed.institution].filter(Boolean).join(' — ');
+      if (t) lines.push(t);
+    }
+  }
+  const text = lines.join('\n\n').trim() || (profile as { summary?: string }).summary || '';
+
+  return {
+    text,
+    parsed: data.profile ?? null,
+    contact_info: data.contact_info ?? null,
+    parsed_at: new Date().toISOString(),
+  };
+}
+
+function skillsListFromParse(data: ParseResumeResponse): string[] {
+  const fromProfile = (data.profile as { skills?: unknown } | undefined)?.skills;
+  if (Array.isArray(fromProfile)) {
+    return fromProfile.map((s) => String(s)).filter(Boolean);
+  }
+  const fromChain = data.skills?.skills;
+  if (Array.isArray(fromChain)) {
+    return fromChain.map((s) => String(s)).filter(Boolean);
+  }
+  return [];
+}
+
+export async function persistParseToProfile(
+  userId: string,
+  data: ParseResumeResponse
+): Promise<{ error: Error | null }> {
+  const skills = skillsListFromParse(data);
+  const experience = buildExperiencePayload(data);
+
+  const { data: existing, error: selErr } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (selErr) return { error: selErr };
+
+  if (existing) {
+    const { error } = await supabase
+      .from('profiles')
+      .update({ skills, experience })
+      .eq('user_id', userId);
+    return { error: error || null };
+  }
+
+  const { error } = await supabase.from('profiles').insert({
+    id: userId,
+    user_id: userId,
+    skills,
+    experience,
+  });
+  return { error: error || null };
+}
+
+type UploadFormProps = {
+  onParsed?: (data: ParseResumeResponse) => void;
+  className?: string;
+};
+
+export default function UploadForm({ onParsed, className = '' }: UploadFormProps) {
   const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<ParseState>('idle');
+  const [message, setMessage] = useState('');
+  const [result, setResult] = useState<ParseResumeResponse | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: Upload to Supabase Storage and trigger FastAPI parse
+    setMessage('');
+    setResult(null);
+
+    if (!file) {
+      setStatus('error');
+      setMessage('Choose a PDF or image file first.');
+      return;
+    }
+
+    setStatus('uploading');
+
+    const sessionRes = await supabase.auth.getSession();
+    const userId = sessionRes.data.session?.user?.id;
+    if (!userId) {
+      setStatus('error');
+      setMessage('You must be signed in to parse and save your profile.');
+      return;
+    }
+
+    const body = new FormData();
+    body.append('file', file);
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/parse/resume`, {
+        method: 'POST',
+        body,
+      });
+
+      const data = (await res.json()) as ParseResumeResponse;
+
+      if (!res.ok) {
+        setStatus('error');
+        setMessage(
+          typeof data === 'object' && data && 'detail' in data
+            ? String((data as { detail?: unknown }).detail)
+            : `Request failed (${res.status})`
+        );
+        return;
+      }
+
+      if (data.error) {
+        setStatus('error');
+        setMessage(String(data.error));
+        return;
+      }
+
+      setResult(data);
+      onParsed?.(data);
+
+      setStatus('saving');
+      const { error: saveErr } = await persistParseToProfile(userId, data);
+      if (saveErr) {
+        setStatus('error');
+        setMessage(`Parsed OK, but could not save to Supabase: ${saveErr.message}`);
+        return;
+      }
+
+      setStatus('success');
+      setMessage('Profile updated from your resume and saved.');
+    } catch (err) {
+      setStatus('error');
+      setMessage(err instanceof Error ? err.message : 'Network error — is the API running?');
+    }
   };
 
+  const profile = result?.profile as
+    | {
+        name?: string;
+        summary?: string;
+        skills?: string[];
+        education?: unknown[];
+        experience?: unknown[];
+      }
+    | undefined;
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <input
-        type="file"
-        accept=".pdf"
-        onChange={(e) => setFile(e.target.files?.[0] || null)}
-        className="border p-2"
-      />
-      <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
-        Upload Resume
-      </button>
-    </form>
+    <div className={`space-y-4 ${className}`}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-white/80 mb-2">Resume file</label>
+          <input
+            type="file"
+            accept=".pdf,.png,.jpg,.jpeg,.bmp,.tiff"
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+            className="block w-full text-sm text-white/80 file:mr-4 file:rounded-lg file:border-0 file:bg-white/10 file:px-4 file:py-2 file:text-white hover:file:bg-white/20"
+          />
+          <p className="text-xs text-white/40 mt-1">PDF or image. Sent to POST /parse/resume, then stored in your profile.</p>
+        </div>
+        <button
+          type="submit"
+          disabled={status === 'uploading' || status === 'saving'}
+          className="px-5 py-2.5 rounded-xl bg-white text-black font-semibold hover:bg-white/90 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {status === 'uploading' || status === 'saving' ? 'Processing…' : 'Parse & save profile'}
+        </button>
+      </form>
+
+      {message && (
+        <div
+          className={`p-3 rounded-lg text-sm border ${
+            status === 'error'
+              ? 'border-red-400/30 bg-red-500/10 text-red-200'
+              : 'border-emerald-400/30 bg-emerald-500/10 text-emerald-200'
+          }`}
+        >
+          {message}
+        </div>
+      )}
+
+      {result && profile && status !== 'error' && (
+        <div className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-3 text-sm">
+          <div className="text-white/90 font-semibold">Parsed profile</div>
+          {profile.name && <p className="text-white/80">Name: {profile.name}</p>}
+          {profile.summary && <p className="text-white/70 whitespace-pre-wrap">{profile.summary}</p>}
+          {Array.isArray(profile.skills) && profile.skills.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {profile.skills.map((s) => (
+                <span key={s} className="px-2 py-0.5 rounded-md bg-white/10 text-white/85 text-xs">
+                  {s}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,11 @@
+/**
+ * Base URL for the FastAPI backend (local dev or hosted).
+ * Set in `frontend/.env.local`, e.g. NEXT_PUBLIC_API_BASE_URL=https://api.example.com
+ */
+export function getApiBaseUrl(): string {
+  const raw = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    return raw.replace(/\/$/, '');
+  }
+  return 'http://127.0.0.1:8000';
+}

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -3,18 +3,30 @@ import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl || !supabaseKey) {
-  throw new Error(
-    'Missing Supabase environment variables. Please create a .env.local file in the frontend directory with:\n' +
-    'NEXT_PUBLIC_SUPABASE_URL=your_supabase_url\n' +
-    'NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key\n\n' +
-    'Get these values from your Supabase project settings: https://app.supabase.com/project/_/settings/api'
+const missingEnvError =
+  'Missing Supabase environment variables. Please create a .env.local file in the frontend directory with:\n' +
+  'NEXT_PUBLIC_SUPABASE_URL=your_supabase_url\n' +
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key\n\n' +
+  'Get these values from your Supabase project settings: https://app.supabase.com/project/_/settings/api';
+
+function createThrowingSupabaseClient() {
+  return new Proxy(
+    {},
+    {
+      get() {
+        throw new Error(missingEnvError);
+      },
+    }
   );
 }
 
-export const supabase = createSupabaseClient(supabaseUrl, supabaseKey);
+export const supabase =
+  supabaseUrl && supabaseKey ? createSupabaseClient(supabaseUrl, supabaseKey) : (createThrowingSupabaseClient() as any);
 
 // Client-side function to create Supabase client
 export const createClient = () => {
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error(missingEnvError);
+  }
   return createSupabaseClient(supabaseUrl, supabaseKey);
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "Job-MCP-frontend",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "job-mcp",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "npm run dev --prefix frontend",
     "build": "npm run build --prefix frontend",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ python-multipart==0.0.12
 # ── LangChain Core ─────────────────────────────────────────────────────
 langchain>=0.3.0
 langchain-core>=0.3.0
+langchain-text-splitters>=0.3.0
 
 # ── LLM Providers (install the ones you need) ──────────────────────────
 langchain-anthropic>=0.3.1       # Anthropic Claude
@@ -27,6 +28,9 @@ paddleocr>=2.7.0
 
 # ── Database ───────────────────────────────────────────────────────────
 supabase==2.9.1
+
+# ── Testing ───────────────────────────────────────────────────────────
+pytest>=7.4.0
 
 # ── Job scraper (scripts/) ─────────────────────────────────────────────
 requests>=2.31.0


### PR DESCRIPTION
## Summary
- Adds `/apply` page to start auto-apply (`POST /apply/start`).
- Polls status (`GET /apply/status/{task_id}`) and renders updates.

## Notes
- This PR depends on PR #25 (CI/build fixes) and PR #27 (shared API client + upload plumbing).

## Test plan
- Run API + celery worker + redis.
- Open `/apply`, queue a URL, verify task status transitions.


Made with [Cursor](https://cursor.com)