### PR TITLE
feat: profile page editor

### DIFF
--- a/backend/app/chains/__init__.py
+++ b/backend/app/chains/__init__.py
@@ -15,7 +15,6 @@ from backend.app.chains.skill_chain import build_skill_chain
 from backend.app.chains.job_match_chain import build_job_match_chain
 from backend.app.chains.cover_letter_chain import build_cover_letter_chain
 from backend.app.chains.resume_writer_chain import build_resume_writer_chain
-from backend.app.chains.apply_agent import build_apply_agent
 
 __all__ = [
     "build_resume_chain",
@@ -23,5 +22,4 @@ __all__ = [
     "build_job_match_chain",
     "build_cover_letter_chain",
     "build_resume_writer_chain",
-    "build_apply_agent",
 ]

--- a/backend/app/services/resume_processor.py
+++ b/backend/app/services/resume_processor.py
@@ -91,7 +91,7 @@ def extract_contact_info(text: str) -> dict:
     emails = re.findall(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b", text)
     if emails:
         info["email"] = emails[0]
-    phones = re.findall(r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b", text)
+    phones = re.findall(r"\b(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})\b", text)
     if phones:
         info["phone"] = f"({phones[0][0]}) {phones[0][1]}-{phones[0][2]}"
     return info

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 
 /**
  * Finishes Google OAuth. The Supabase client reads tokens from the redirect URL
@@ -13,7 +14,7 @@ export default function AuthCallbackPage() {
   const [message, setMessage] = useState('Signing in…');
 
   useEffect(() => {
-    const { data: listener } = supabase.auth.onAuthStateChange((event, session) => {
+    const { data: listener } = supabase.auth.onAuthStateChange((event: AuthChangeEvent, session: Session | null) => {
       if (session && (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED')) {
         listener.subscription.unsubscribe();
         router.replace('/dashboard');

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 
 type DashboardJob = {
   id: string;
@@ -191,7 +192,7 @@ export default function Dashboard() {
     // Listen for auth changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange((_event: AuthChangeEvent, session: Session | null) => {
       if (!session) {
         router.push('/login');
       } else {

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,30 +1,37 @@
-"use client";
+'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
+import UploadForm from '@/components/UploadForm';
 
-type ProfileRow = {
-  skills: unknown;
-  experience: unknown;
+type ExperienceShape = {
+  text?: string;
+  parsed?: Record<string, unknown>;
+  contact_info?: unknown;
+  parsed_at?: string;
 } | null;
 
 type PreferencesRow = {
   job_types: unknown;
 } | null;
 
+function normalizeSkills(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((v) => String(v).trim()).filter(Boolean);
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
 function toCommaString(value: unknown): string {
   if (!value) return '';
   if (Array.isArray(value)) return value.map((v) => String(v)).join(', ');
   if (typeof value === 'string') return value;
   return '';
-}
-
-function parseSkillsInput(input: string): string[] {
-  return input
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
 }
 
 function parseJobTypesInput(input: string): string[] {
@@ -38,12 +45,16 @@ function toExperienceText(value: unknown): string {
   if (!value) return '';
   if (typeof value === 'string') return value;
   if (typeof value === 'object') {
-    // Common shape we store: { text: "..." }
-    const maybeObj = value as any;
+    const maybeObj = value as { text?: string; experience?: string };
     if (typeof maybeObj.text === 'string') return maybeObj.text;
     if (typeof maybeObj.experience === 'string') return maybeObj.experience;
   }
   return '';
+}
+
+function getExperienceObject(value: unknown): ExperienceShape {
+  if (!value || typeof value !== 'object') return null;
+  return value as ExperienceShape;
 }
 
 export default function Profile() {
@@ -52,26 +63,56 @@ export default function Profile() {
   const [authLoading, setAuthLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [editMode, setEditMode] = useState(false);
-  const [error, setError] = useState<string>('');
-  const [success, setSuccess] = useState<string>('');
-
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
   const [userId, setUserId] = useState<string | null>(null);
 
-  const [skillsInput, setSkillsInput] = useState('');
+  const [skillTags, setSkillTags] = useState<string[]>([]);
+  const [skillDraft, setSkillDraft] = useState('');
   const [experienceInput, setExperienceInput] = useState('');
   const [jobTypesInput, setJobTypesInput] = useState('');
+  const [parsedFromDb, setParsedFromDb] = useState<Record<string, unknown> | null>(null);
 
-  // Used for "Cancel" to restore what was loaded from Supabase
-  const [initialSkillsInput, setInitialSkillsInput] = useState('');
+  const [initialSkillTags, setInitialSkillTags] = useState<string[]>([]);
   const [initialExperienceInput, setInitialExperienceInput] = useState('');
   const [initialJobTypesInput, setInitialJobTypesInput] = useState('');
 
+  const loadProfile = useCallback(async (uid: string) => {
+    const { data: profileData, error: profileErr } = await supabase
+      .from('profiles')
+      .select('skills, experience')
+      .eq('user_id', uid)
+      .maybeSingle();
+
+    if (profileErr) throw profileErr;
+
+    const skills = normalizeSkills((profileData as { skills?: unknown } | null)?.skills);
+    setSkillTags(skills);
+    setInitialSkillTags(skills);
+
+    const expObj = getExperienceObject((profileData as { experience?: unknown } | null)?.experience);
+    setExperienceInput(toExperienceText((profileData as { experience?: unknown } | null)?.experience));
+    setInitialExperienceInput(toExperienceText((profileData as { experience?: unknown } | null)?.experience));
+    if (expObj?.parsed && typeof expObj.parsed === 'object') {
+      setParsedFromDb(expObj.parsed as Record<string, unknown>);
+    } else {
+      setParsedFromDb(null);
+    }
+
+    const { data: prefData, error: prefErr } = await supabase.from('preferences').select('job_types').eq('user_id', uid).maybeSingle();
+
+    if (prefErr) throw prefErr;
+
+    const jt = toCommaString((prefData as PreferencesRow)?.job_types);
+    setJobTypesInput(jt);
+    setInitialJobTypesInput(jt);
+  }, []);
+
   const savePayload = useMemo(() => {
-    const skills = parseSkillsInput(skillsInput);
-    const experience = { text: experienceInput.trim() };
-    const job_types = parseJobTypesInput(jobTypesInput);
-    return { skills, experience, job_types };
-  }, [skillsInput, experienceInput, jobTypesInput]);
+    const experience: Record<string, unknown> = { text: experienceInput.trim() };
+    if (parsedFromDb) experience.parsed = parsedFromDb;
+    return { skills: skillTags, experience, job_types: parseJobTypesInput(jobTypesInput) };
+  }, [skillTags, experienceInput, jobTypesInput, parsedFromDb]);
 
   useEffect(() => {
     const init = async () => {
@@ -89,52 +130,20 @@ export default function Profile() {
 
       setUserId(session.user.id);
 
-      // Load existing profile
-      const { data: profileData, error: profileErr } = await supabase
-        .from('profiles')
-        .select('skills,experience')
-        .eq('user_id', session.user.id)
-        .maybeSingle();
-
-      if (profileErr) {
-        setError(profileErr.message);
+      try {
+        await loadProfile(session.user.id);
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'Failed to load profile');
         setAuthLoading(false);
         return;
       }
-
-      const profileRow: ProfileRow = profileData ?? null;
-      setSkillsInput(toCommaString((profileRow as any)?.skills));
-      setExperienceInput(toExperienceText((profileRow as any)?.experience));
-      const nextSkillsInput = toCommaString((profileRow as any)?.skills);
-      const nextExperienceInput = toExperienceText((profileRow as any)?.experience);
-      setInitialSkillsInput(nextSkillsInput);
-      setInitialExperienceInput(nextExperienceInput);
-
-      // Load existing preferences
-      const { data: prefData, error: prefErr } = await supabase
-        .from('preferences')
-        .select('job_types')
-        .eq('user_id', session.user.id)
-        .maybeSingle();
-
-      if (prefErr) {
-        setError(prefErr.message);
-        setAuthLoading(false);
-        return;
-      }
-
-      const prefRow: PreferencesRow = prefData ?? null;
-      setJobTypesInput(toCommaString((prefRow as any)?.job_types));
-      const nextJobTypesInput = toCommaString((prefRow as any)?.job_types);
-      setInitialJobTypesInput(nextJobTypesInput);
 
       setEditMode(false);
-
       setAuthLoading(false);
     };
 
     init();
-  }, [router]);
+  }, [router, loadProfile]);
 
   const handleSave = async () => {
     if (!userId) return;
@@ -143,7 +152,6 @@ export default function Profile() {
     setSuccess('');
 
     try {
-      // Upsert-ish for profiles (insert with deterministic ID if absent)
       const { data: existingProfile, error: existingProfileErr } = await supabase
         .from('profiles')
         .select('id')
@@ -163,7 +171,6 @@ export default function Profile() {
 
         if (updateErr) throw updateErr;
       } else {
-        // If your `profiles.id` doesn't have a default, we set it to `user_id` to avoid null inserts.
         const { error: insertErr } = await supabase.from('profiles').insert({
           id: userId,
           user_id: userId,
@@ -174,7 +181,6 @@ export default function Profile() {
         if (insertErr) throw insertErr;
       }
 
-      // Upsert-ish for preferences
       const { data: existingPref, error: existingPrefErr } = await supabase
         .from('preferences')
         .select('id')
@@ -201,17 +207,37 @@ export default function Profile() {
       }
 
       setSuccess('Profile saved.');
-      // Treat the saved values as the new "loaded" state for cancel/reset.
-      setInitialSkillsInput(skillsInput);
+      setInitialSkillTags([...skillTags]);
       setInitialExperienceInput(experienceInput);
       setInitialJobTypesInput(jobTypesInput);
       setEditMode(false);
-    } catch (e: any) {
-      setError(e?.message || 'Failed to save profile. Check Supabase logs/RLS policies.');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to save profile. Check Supabase logs/RLS policies.');
     } finally {
       setSaving(false);
     }
   };
+
+  const addSkillTag = () => {
+    const next = skillDraft.trim();
+    if (!next || skillTags.includes(next)) return;
+    setSkillTags((s) => [...s, next]);
+    setSkillDraft('');
+  };
+
+  const removeSkillTag = (tag: string) => {
+    setSkillTags((s) => s.filter((t) => t !== tag));
+  };
+
+  const onResumeParsed = useCallback(async () => {
+    if (!userId) return;
+    setSuccess('Resume parsed and saved to your profile.');
+    try {
+      await loadProfile(userId);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to refresh profile after parse');
+    }
+  }, [userId, loadProfile]);
 
   if (authLoading) {
     return (
@@ -227,34 +253,42 @@ export default function Profile() {
         <div className="mb-6">
           <h1 className="text-3xl font-bold mb-2">Profile Management</h1>
           <p className="text-white/60">
-            Update your skills, experience, and job types. These are used by the auto-apply flow.
+            Upload a resume to parse with AI, edit skills as tags, and tune preferences for auto-apply.
           </p>
         </div>
 
         {error && (
-          <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-300 text-sm">
-            {error}
-          </div>
+          <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-300 text-sm">{error}</div>
         )}
 
         {success && (
-          <div className="mb-4 p-3 bg-green-500/10 border border-green-500/20 rounded-lg text-green-300 text-sm">
-            {success}
-          </div>
+          <div className="mb-4 p-3 bg-green-500/10 border border-green-500/20 rounded-lg text-green-300 text-sm">{success}</div>
+        )}
+
+        <section className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-2xl p-6 mb-8">
+          <h2 className="text-lg font-semibold text-white mb-4">Resume upload</h2>
+          <UploadForm onParsed={onResumeParsed} />
+        </section>
+
+        {parsedFromDb && (
+          <section className="backdrop-blur-xl bg-emerald-500/5 border border-emerald-400/20 rounded-2xl p-6 mb-8">
+            <h3 className="text-md font-semibold text-emerald-100 mb-3">Stored parsed profile snapshot</h3>
+            <pre className="text-xs text-white/70 overflow-x-auto whitespace-pre-wrap max-h-64 rounded-lg bg-black/40 p-4 border border-white/10">
+              {JSON.stringify(parsedFromDb, null, 2)}
+            </pre>
+          </section>
         )}
 
         <div className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-2xl p-6">
           <div className="flex items-center justify-between gap-4 mb-5">
-            <div className="text-white/80 font-semibold">
-              {editMode ? 'Editing profile' : 'View profile'}
-            </div>
+            <div className="text-white/80 font-semibold">{editMode ? 'Editing profile' : 'View profile'}</div>
             {!editMode ? (
               <button
                 type="button"
                 onClick={() => {
                   setError('');
                   setSuccess('');
-                  setSkillsInput(initialSkillsInput);
+                  setSkillTags([...initialSkillTags]);
                   setExperienceInput(initialExperienceInput);
                   setJobTypesInput(initialJobTypesInput);
                   setEditMode(true);
@@ -270,7 +304,7 @@ export default function Profile() {
                   onClick={() => {
                     setError('');
                     setSuccess('');
-                    setSkillsInput(initialSkillsInput);
+                    setSkillTags([...initialSkillTags]);
                     setExperienceInput(initialExperienceInput);
                     setJobTypesInput(initialJobTypesInput);
                     setEditMode(false);
@@ -294,15 +328,60 @@ export default function Profile() {
 
           <div className="space-y-5">
             <section className="space-y-2">
-              <label className="block text-sm font-medium text-white/80">Skills (comma separated)</label>
-              <textarea
-                value={skillsInput}
-                onChange={(e) => setSkillsInput(e.target.value)}
-                rows={4}
-                placeholder="python, sql, postgres, react, aws"
-                className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:outline-none focus:border-white/30 focus:bg-white/10 transition-all"
-                disabled={!editMode}
-              />
+              <label className="block text-sm font-medium text-white/80">Skills</label>
+              {!editMode ? (
+                <div className="flex flex-wrap gap-2 min-h-[2.5rem]">
+                  {skillTags.length ? (
+                    skillTags.map((s) => (
+                      <span
+                        key={s}
+                        className="px-2.5 py-1 rounded-lg bg-white/10 border border-white/10 text-sm text-white/90"
+                      >
+                        {s}
+                      </span>
+                    ))
+                  ) : (
+                    <span className="text-white/40 text-sm">No skills yet — parse a resume or edit your profile.</span>
+                  )}
+                </div>
+              ) : (
+                <>
+                  <div className="flex flex-wrap gap-2 mb-2">
+                    {skillTags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white/10 border border-white/15 text-sm"
+                      >
+                        {tag}
+                        <button type="button" className="text-white/60 hover:text-white ml-1" onClick={() => removeSkillTag(tag)}>
+                          ×
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                  <div className="flex gap-2">
+                    <input
+                      value={skillDraft}
+                      onChange={(e) => setSkillDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          addSkillTag();
+                        }
+                      }}
+                      placeholder="Type a skill, press Enter"
+                      className="flex-1 px-4 py-2.5 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40"
+                    />
+                    <button
+                      type="button"
+                      onClick={addSkillTag}
+                      className="px-4 py-2 rounded-xl bg-white/10 border border-white/15 text-white hover:bg-white/15"
+                    >
+                      Add
+                    </button>
+                  </div>
+                </>
+              )}
             </section>
 
             <section className="space-y-2">
@@ -328,10 +407,6 @@ export default function Profile() {
               />
             </section>
           </div>
-        </div>
-
-        <div className="mt-6 text-sm text-white/50">
-          Note: resume upload + parsing can be added next once the `/parse/resume` backend endpoint is implemented.
         </div>
       </div>
     </main>

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import LiquidGlassButton from './LiquidGlassButton';
 import { supabase } from '@/lib/supabase';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 
 export default function Navbar() {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -22,7 +23,8 @@ export default function Navbar() {
 
   useEffect(() => {
     // Check initial auth state
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    supabase.auth.getSession().then(({ data }: { data: { session: Session | null } }) => {
+      const { session } = data;
       setIsSignedIn(!!session);
       setUserEmail(session?.user?.email || '');
     });
@@ -30,7 +32,7 @@ export default function Navbar() {
     // Listen for auth changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange((_event: AuthChangeEvent, session: Session | null) => {
       setIsSignedIn(!!session);
       setUserEmail(session?.user?.email || '');
     });
@@ -79,13 +81,30 @@ export default function Navbar() {
           {/* Right Actions */}
           <div className="flex items-center space-x-4">
             {isSignedIn ? (
-              // Signed In: Show Dashboard and Sign Out
+              // Signed In: Show app nav and Sign Out
               <>
+                <Link
+                  href="/dashboard"
+                  className="hidden sm:block text-sm font-medium text-white/70 hover:text-white transition-colors"
+                >
+                  Dashboard
+                </Link>
+                <Link
+                  href="/apply"
+                  className="hidden sm:block text-sm font-medium text-white/70 hover:text-white transition-colors"
+                >
+                  Auto-apply
+                </Link>
+                <Link
+                  href="/profile"
+                  className="hidden sm:block text-sm font-medium text-white/70 hover:text-white transition-colors"
+                >
+                  Profile
+                </Link>
                 <Link
                   href="/dashboard"
                   className="flex items-center space-x-2 text-sm font-medium text-white hover:opacity-80 transition-opacity"
                 >
-                  <span className="hidden md:inline">Dashboard</span>
                   <span className="px-2 py-1 text-xs font-medium bg-white/10 text-white rounded border border-white/20">
                     {userEmail.charAt(0).toUpperCase()}
                   </span>

--- a/frontend/components/UploadForm.tsx
+++ b/frontend/components/UploadForm.tsx
@@ -1,24 +1,235 @@
-import { useState } from 'react';
+'use client';
 
-export default function UploadForm() {
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { getApiBaseUrl } from '@/lib/api';
+
+export type ParseResumeResponse = {
+  file_name?: string;
+  profile?: Record<string, unknown>;
+  skills?: { skills?: string[]; categorized?: Record<string, unknown> };
+  contact_info?: { email?: string; phone?: string } | null;
+  processing_status?: string;
+  error?: string;
+};
+
+type ParseState = 'idle' | 'uploading' | 'saving' | 'success' | 'error';
+
+function buildExperiencePayload(
+  data: ParseResumeResponse
+): { text: string; parsed: unknown; contact_info: unknown; parsed_at: string } {
+  const profile = (data.profile || {}) as {
+    summary?: string;
+    experience?: Array<{ company?: string; title?: string; description?: string }>;
+    education?: Array<{ degree?: string; institution?: string }>;
+  };
+  const lines: string[] = [];
+  if (profile.summary) lines.push(profile.summary);
+  if (Array.isArray(profile.experience)) {
+    for (const ex of profile.experience) {
+      const t = [ex.title, ex.company].filter(Boolean).join(' @ ');
+      if (t) lines.push(t);
+      if (ex.description) lines.push(ex.description);
+    }
+  }
+  if (Array.isArray(profile.education)) {
+    for (const ed of profile.education) {
+      const t = [ed.degree, ed.institution].filter(Boolean).join(' — ');
+      if (t) lines.push(t);
+    }
+  }
+  const text = lines.join('\n\n').trim() || (profile as { summary?: string }).summary || '';
+
+  return {
+    text,
+    parsed: data.profile ?? null,
+    contact_info: data.contact_info ?? null,
+    parsed_at: new Date().toISOString(),
+  };
+}
+
+function skillsListFromParse(data: ParseResumeResponse): string[] {
+  const fromProfile = (data.profile as { skills?: unknown } | undefined)?.skills;
+  if (Array.isArray(fromProfile)) {
+    return fromProfile.map((s) => String(s)).filter(Boolean);
+  }
+  const fromChain = data.skills?.skills;
+  if (Array.isArray(fromChain)) {
+    return fromChain.map((s) => String(s)).filter(Boolean);
+  }
+  return [];
+}
+
+export async function persistParseToProfile(
+  userId: string,
+  data: ParseResumeResponse
+): Promise<{ error: Error | null }> {
+  const skills = skillsListFromParse(data);
+  const experience = buildExperiencePayload(data);
+
+  const { data: existing, error: selErr } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (selErr) return { error: selErr };
+
+  if (existing) {
+    const { error } = await supabase
+      .from('profiles')
+      .update({ skills, experience })
+      .eq('user_id', userId);
+    return { error: error || null };
+  }
+
+  const { error } = await supabase.from('profiles').insert({
+    id: userId,
+    user_id: userId,
+    skills,
+    experience,
+  });
+  return { error: error || null };
+}
+
+type UploadFormProps = {
+  onParsed?: (data: ParseResumeResponse) => void;
+  className?: string;
+};
+
+export default function UploadForm({ onParsed, className = '' }: UploadFormProps) {
   const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<ParseState>('idle');
+  const [message, setMessage] = useState('');
+  const [result, setResult] = useState<ParseResumeResponse | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: Upload to Supabase Storage and trigger FastAPI parse
+    setMessage('');
+    setResult(null);
+
+    if (!file) {
+      setStatus('error');
+      setMessage('Choose a PDF or image file first.');
+      return;
+    }
+
+    setStatus('uploading');
+
+    const sessionRes = await supabase.auth.getSession();
+    const userId = sessionRes.data.session?.user?.id;
+    if (!userId) {
+      setStatus('error');
+      setMessage('You must be signed in to parse and save your profile.');
+      return;
+    }
+
+    const body = new FormData();
+    body.append('file', file);
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/parse/resume`, {
+        method: 'POST',
+        body,
+      });
+
+      const data = (await res.json()) as ParseResumeResponse;
+
+      if (!res.ok) {
+        setStatus('error');
+        setMessage(
+          typeof data === 'object' && data && 'detail' in data
+            ? String((data as { detail?: unknown }).detail)
+            : `Request failed (${res.status})`
+        );
+        return;
+      }
+
+      if (data.error) {
+        setStatus('error');
+        setMessage(String(data.error));
+        return;
+      }
+
+      setResult(data);
+      onParsed?.(data);
+
+      setStatus('saving');
+      const { error: saveErr } = await persistParseToProfile(userId, data);
+      if (saveErr) {
+        setStatus('error');
+        setMessage(`Parsed OK, but could not save to Supabase: ${saveErr.message}`);
+        return;
+      }
+
+      setStatus('success');
+      setMessage('Profile updated from your resume and saved.');
+    } catch (err) {
+      setStatus('error');
+      setMessage(err instanceof Error ? err.message : 'Network error — is the API running?');
+    }
   };
 
+  const profile = result?.profile as
+    | {
+        name?: string;
+        summary?: string;
+        skills?: string[];
+        education?: unknown[];
+        experience?: unknown[];
+      }
+    | undefined;
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <input
-        type="file"
-        accept=".pdf"
-        onChange={(e) => setFile(e.target.files?.[0] || null)}
-        className="border p-2"
-      />
-      <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
-        Upload Resume
-      </button>
-    </form>
+    <div className={`space-y-4 ${className}`}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-white/80 mb-2">Resume file</label>
+          <input
+            type="file"
+            accept=".pdf,.png,.jpg,.jpeg,.bmp,.tiff"
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+            className="block w-full text-sm text-white/80 file:mr-4 file:rounded-lg file:border-0 file:bg-white/10 file:px-4 file:py-2 file:text-white hover:file:bg-white/20"
+          />
+          <p className="text-xs text-white/40 mt-1">PDF or image. Sent to POST /parse/resume, then stored in your profile.</p>
+        </div>
+        <button
+          type="submit"
+          disabled={status === 'uploading' || status === 'saving'}
+          className="px-5 py-2.5 rounded-xl bg-white text-black font-semibold hover:bg-white/90 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {status === 'uploading' || status === 'saving' ? 'Processing…' : 'Parse & save profile'}
+        </button>
+      </form>
+
+      {message && (
+        <div
+          className={`p-3 rounded-lg text-sm border ${
+            status === 'error'
+              ? 'border-red-400/30 bg-red-500/10 text-red-200'
+              : 'border-emerald-400/30 bg-emerald-500/10 text-emerald-200'
+          }`}
+        >
+          {message}
+        </div>
+      )}
+
+      {result && profile && status !== 'error' && (
+        <div className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-3 text-sm">
+          <div className="text-white/90 font-semibold">Parsed profile</div>
+          {profile.name && <p className="text-white/80">Name: {profile.name}</p>}
+          {profile.summary && <p className="text-white/70 whitespace-pre-wrap">{profile.summary}</p>}
+          {Array.isArray(profile.skills) && profile.skills.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {profile.skills.map((s) => (
+                <span key={s} className="px-2 py-0.5 rounded-md bg-white/10 text-white/85 text-xs">
+                  {s}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,11 @@
+/**
+ * Base URL for the FastAPI backend (local dev or hosted).
+ * Set in `frontend/.env.local`, e.g. NEXT_PUBLIC_API_BASE_URL=https://api.example.com
+ */
+export function getApiBaseUrl(): string {
+  const raw = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    return raw.replace(/\/$/, '');
+  }
+  return 'http://127.0.0.1:8000';
+}

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -3,18 +3,30 @@ import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl || !supabaseKey) {
-  throw new Error(
-    'Missing Supabase environment variables. Please create a .env.local file in the frontend directory with:\n' +
-    'NEXT_PUBLIC_SUPABASE_URL=your_supabase_url\n' +
-    'NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key\n\n' +
-    'Get these values from your Supabase project settings: https://app.supabase.com/project/_/settings/api'
+const missingEnvError =
+  'Missing Supabase environment variables. Please create a .env.local file in the frontend directory with:\n' +
+  'NEXT_PUBLIC_SUPABASE_URL=your_supabase_url\n' +
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key\n\n' +
+  'Get these values from your Supabase project settings: https://app.supabase.com/project/_/settings/api';
+
+function createThrowingSupabaseClient() {
+  return new Proxy(
+    {},
+    {
+      get() {
+        throw new Error(missingEnvError);
+      },
+    }
   );
 }
 
-export const supabase = createSupabaseClient(supabaseUrl, supabaseKey);
+export const supabase =
+  supabaseUrl && supabaseKey ? createSupabaseClient(supabaseUrl, supabaseKey) : (createThrowingSupabaseClient() as any);
 
 // Client-side function to create Supabase client
 export const createClient = () => {
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error(missingEnvError);
+  }
   return createSupabaseClient(supabaseUrl, supabaseKey);
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "Job-MCP-frontend",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "job-mcp",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "npm run dev --prefix frontend",
     "build": "npm run build --prefix frontend",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ python-multipart==0.0.12
 # ── LangChain Core ─────────────────────────────────────────────────────
 langchain>=0.3.0
 langchain-core>=0.3.0
+langchain-text-splitters>=0.3.0
 
 # ── LLM Providers (install the ones you need) ──────────────────────────
 langchain-anthropic>=0.3.1       # Anthropic Claude
@@ -27,6 +28,9 @@ paddleocr>=2.7.0
 
 # ── Database ───────────────────────────────────────────────────────────
 supabase==2.9.1
+
+# ── Testing ───────────────────────────────────────────────────────────
+pytest>=7.4.0
 
 # ── Job scraper (scripts/) ─────────────────────────────────────────────
 requests>=2.31.0


### PR DESCRIPTION
## Summary
- Builds out `/profile` to fetch, display, and edit the parsed profile.
- Implements skills as editable tags and persists preferences.

## Notes
- This PR depends on PR #25 (CI/build fixes) and PR #27 (resume upload + API client).

## Test plan
- Sign in, open `/profile`.
- Verify skills/experience/preferences load and save.
- Upload resume to populate profile.


Made with [Cursor](https://cursor.com)